### PR TITLE
V3 transfers

### DIFF
--- a/abis/ERC20.json
+++ b/abis/ERC20.json
@@ -1,0 +1,354 @@
+[{
+	"inputs": [{
+		"internalType": "string",
+		"name": "symbol_",
+		"type": "string"
+	}, {
+		"internalType": "string",
+		"name": "name_",
+		"type": "string"
+	}],
+	"payable": false,
+	"stateMutability": "nonpayable",
+	"type": "constructor"
+}, {
+	"anonymous": false,
+	"inputs": [{
+		"indexed": true,
+		"internalType": "address",
+		"name": "src",
+		"type": "address"
+	}, {
+		"indexed": true,
+		"internalType": "address",
+		"name": "usr",
+		"type": "address"
+	}, {
+		"indexed": false,
+		"internalType": "uint256",
+		"name": "wad",
+		"type": "uint256"
+	}],
+	"name": "Approval",
+	"type": "event"
+}, {
+	"anonymous": false,
+	"inputs": [{
+		"indexed": true,
+		"internalType": "address",
+		"name": "src",
+		"type": "address"
+	}, {
+		"indexed": true,
+		"internalType": "address",
+		"name": "dst",
+		"type": "address"
+	}, {
+		"indexed": false,
+		"internalType": "uint256",
+		"name": "wad",
+		"type": "uint256"
+	}],
+	"name": "Transfer",
+	"type": "event"
+}, {
+	"constant": true,
+	"inputs": [{
+		"internalType": "address",
+		"name": "",
+		"type": "address"
+	}, {
+		"internalType": "address",
+		"name": "",
+		"type": "address"
+	}],
+	"name": "allowance",
+	"outputs": [{
+		"internalType": "uint256",
+		"name": "",
+		"type": "uint256"
+	}],
+	"payable": false,
+	"stateMutability": "view",
+	"type": "function"
+}, {
+	"constant": false,
+	"inputs": [{
+		"internalType": "address",
+		"name": "usr",
+		"type": "address"
+	}, {
+		"internalType": "uint256",
+		"name": "wad",
+		"type": "uint256"
+	}],
+	"name": "approve",
+	"outputs": [{
+		"internalType": "bool",
+		"name": "",
+		"type": "bool"
+	}],
+	"payable": false,
+	"stateMutability": "nonpayable",
+	"type": "function"
+}, {
+	"constant": true,
+	"inputs": [{
+		"internalType": "address",
+		"name": "",
+		"type": "address"
+	}],
+	"name": "balanceOf",
+	"outputs": [{
+		"internalType": "uint256",
+		"name": "",
+		"type": "uint256"
+	}],
+	"payable": false,
+	"stateMutability": "view",
+	"type": "function"
+}, {
+	"constant": false,
+	"inputs": [{
+		"internalType": "address",
+		"name": "usr",
+		"type": "address"
+	}, {
+		"internalType": "uint256",
+		"name": "wad",
+		"type": "uint256"
+	}],
+	"name": "burn",
+	"outputs": [],
+	"payable": false,
+	"stateMutability": "nonpayable",
+	"type": "function"
+}, {
+	"constant": true,
+	"inputs": [],
+	"name": "decimals",
+	"outputs": [{
+		"internalType": "uint8",
+		"name": "",
+		"type": "uint8"
+	}],
+	"payable": false,
+	"stateMutability": "view",
+	"type": "function"
+}, {
+	"constant": false,
+	"inputs": [{
+		"internalType": "address",
+		"name": "usr",
+		"type": "address"
+	}],
+	"name": "deny",
+	"outputs": [],
+	"payable": false,
+	"stateMutability": "nonpayable",
+	"type": "function"
+}, {
+	"constant": false,
+	"inputs": [{
+		"internalType": "address",
+		"name": "usr",
+		"type": "address"
+	}, {
+		"internalType": "uint256",
+		"name": "wad",
+		"type": "uint256"
+	}],
+	"name": "mint",
+	"outputs": [],
+	"payable": false,
+	"stateMutability": "nonpayable",
+	"type": "function"
+}, {
+	"constant": false,
+	"inputs": [{
+		"internalType": "address",
+		"name": "src",
+		"type": "address"
+	}, {
+		"internalType": "address",
+		"name": "dst",
+		"type": "address"
+	}, {
+		"internalType": "uint256",
+		"name": "wad",
+		"type": "uint256"
+	}],
+	"name": "move",
+	"outputs": [],
+	"payable": false,
+	"stateMutability": "nonpayable",
+	"type": "function"
+}, {
+	"constant": true,
+	"inputs": [],
+	"name": "name",
+	"outputs": [{
+		"internalType": "string",
+		"name": "",
+		"type": "string"
+	}],
+	"payable": false,
+	"stateMutability": "view",
+	"type": "function"
+}, {
+	"constant": true,
+	"inputs": [{
+		"internalType": "address",
+		"name": "",
+		"type": "address"
+	}],
+	"name": "nonces",
+	"outputs": [{
+		"internalType": "uint256",
+		"name": "",
+		"type": "uint256"
+	}],
+	"payable": false,
+	"stateMutability": "view",
+	"type": "function"
+}, {
+	"constant": false,
+	"inputs": [{
+		"internalType": "address",
+		"name": "usr",
+		"type": "address"
+	}, {
+		"internalType": "uint256",
+		"name": "wad",
+		"type": "uint256"
+	}],
+	"name": "pull",
+	"outputs": [],
+	"payable": false,
+	"stateMutability": "nonpayable",
+	"type": "function"
+}, {
+	"constant": false,
+	"inputs": [{
+		"internalType": "address",
+		"name": "usr",
+		"type": "address"
+	}, {
+		"internalType": "uint256",
+		"name": "wad",
+		"type": "uint256"
+	}],
+	"name": "push",
+	"outputs": [],
+	"payable": false,
+	"stateMutability": "nonpayable",
+	"type": "function"
+}, {
+	"constant": false,
+	"inputs": [{
+		"internalType": "address",
+		"name": "usr",
+		"type": "address"
+	}],
+	"name": "rely",
+	"outputs": [],
+	"payable": false,
+	"stateMutability": "nonpayable",
+	"type": "function"
+}, {
+	"constant": true,
+	"inputs": [],
+	"name": "symbol",
+	"outputs": [{
+		"internalType": "string",
+		"name": "",
+		"type": "string"
+	}],
+	"payable": false,
+	"stateMutability": "view",
+	"type": "function"
+}, {
+	"constant": true,
+	"inputs": [],
+	"name": "totalSupply",
+	"outputs": [{
+		"internalType": "uint256",
+		"name": "",
+		"type": "uint256"
+	}],
+	"payable": false,
+	"stateMutability": "view",
+	"type": "function"
+}, {
+	"constant": false,
+	"inputs": [{
+		"internalType": "address",
+		"name": "dst",
+		"type": "address"
+	}, {
+		"internalType": "uint256",
+		"name": "wad",
+		"type": "uint256"
+	}],
+	"name": "transfer",
+	"outputs": [{
+		"internalType": "bool",
+		"name": "",
+		"type": "bool"
+	}],
+	"payable": false,
+	"stateMutability": "nonpayable",
+	"type": "function"
+}, {
+	"constant": false,
+	"inputs": [{
+		"internalType": "address",
+		"name": "src",
+		"type": "address"
+	}, {
+		"internalType": "address",
+		"name": "dst",
+		"type": "address"
+	}, {
+		"internalType": "uint256",
+		"name": "wad",
+		"type": "uint256"
+	}],
+	"name": "transferFrom",
+	"outputs": [{
+		"internalType": "bool",
+		"name": "",
+		"type": "bool"
+	}],
+	"payable": false,
+	"stateMutability": "nonpayable",
+	"type": "function"
+}, {
+	"constant": true,
+	"inputs": [],
+	"name": "version",
+	"outputs": [{
+		"internalType": "string",
+		"name": "",
+		"type": "string"
+	}],
+	"payable": false,
+	"stateMutability": "view",
+	"type": "function"
+}, {
+	"constant": true,
+	"inputs": [{
+		"internalType": "address",
+		"name": "",
+		"type": "address"
+	}],
+	"name": "wards",
+	"outputs": [{
+		"internalType": "uint256",
+		"name": "",
+		"type": "uint256"
+	}],
+	"payable": false,
+	"stateMutability": "view",
+	"type": "function"
+}]

--- a/schema.graphql
+++ b/schema.graphql
@@ -40,3 +40,32 @@ type Proxy @entity {
   id: ID!
   owner: Bytes!
 }
+
+type Account @entity {
+  id: ID! # address
+  tokenBalances: [TokenBalance!] @derivedFrom (field: "owner")
+  currentActiveInvestmentAmount: BigInt # not based on token balance
+}
+
+type ERC20Transfer @entity {
+  id: ID!
+  transaction: String # txhash
+  token: Token!
+  from: String
+  to: String
+  amount: BigInt
+  pool: Pool!
+}
+
+type Token @entity {
+  id: ID! # token address
+  tokenBalances: [TokenBalance!]! @derivedFrom(field: "token")
+}
+
+type TokenBalance @entity {
+  id: ID! # account address + token address 
+  owner: Account!
+  balance: BigInt!
+  value: BigInt!
+  token: Token!
+}

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -500,8 +500,7 @@ export function handleERC20Transfer(event: TransferEvent): void {
 
   let poolMeta = poolFromAddress(event.address)
   let id = event.block.number.toString().concat('-').concat(event.logIndex.toString())
-  let transfer = ERC20Transfer.load(id)
-  if(transfer == null) {
-    transfer = createERC20Transfer(id, event, poolMeta)
+  if (ERC20Transfer.load(id) == null) {
+    createERC20Transfer(id, event, poolMeta)
   }
 }

--- a/src/mappingUtil.ts
+++ b/src/mappingUtil.ts
@@ -1,5 +1,13 @@
 import { BigInt, Address, log } from "@graphprotocol/graph-ts";
-import { PoolMeta, poolMetaByShelf, poolMetaByPile, poolMetaByNftFeed, poolMetaBySeniorTranche, poolMetaByAssessor, poolMetaById } from "./poolMetas"
+import { PoolMeta, poolMetaByShelf, poolMetaByPile, poolMetaByNftFeed, poolMetaBySeniorTranche, poolMetaByAssessor, poolMetaById, poolMetaByAddress } from "./poolMetas"
+
+export function poolFromAddress(address: Address): PoolMeta {
+  if (!poolMetaByAddress.has(address.toHex())) {
+    log.critical("poolMeta not found for address {}", [address.toHex()])
+  }
+  let poolMeta = poolMetaByAddress.get(address.toHex())
+  return poolMeta
+}
 
 export function poolFromShelf(shelf: Address): PoolMeta {
   if (!poolMetaByShelf.has(shelf.toHex())) {

--- a/src/mappingUtil.ts
+++ b/src/mappingUtil.ts
@@ -1,59 +1,12 @@
-import { BigInt, Address, log } from "@graphprotocol/graph-ts";
-import { PoolMeta, poolMetaByShelf, poolMetaByPile, poolMetaByNftFeed, poolMetaBySeniorTranche, poolMetaByAssessor, poolMetaById, poolMetaByAddress } from "./poolMetas"
+import { BigInt, log } from "@graphprotocol/graph-ts";
+import { PoolMeta, poolMetaByIdentifier } from "../src/poolMetas";
 
-export function poolFromAddress(address: Address): PoolMeta {
-  if (!poolMetaByAddress.has(address.toHex())) {
-    log.critical("poolMeta not found for address {}", [address.toHex()])
+// poolId or address
+export function poolFromIdentifier(id: string): PoolMeta {
+  if (!poolMetaByIdentifier.has(id)) {
+    log.critical("poolMeta not found for identifier {}", [id])
   }
-  let poolMeta = poolMetaByAddress.get(address.toHex())
-  return poolMeta
-}
-
-export function poolFromShelf(shelf: Address): PoolMeta {
-  if (!poolMetaByShelf.has(shelf.toHex())) {
-    log.critical("poolMeta not found for shelf {}", [shelf.toHex()])
-  }
-  let poolMeta = poolMetaByShelf.get(shelf.toHex())
-  return poolMeta
-}
-
-export function poolFromId(id: string): PoolMeta {
-  if (!poolMetaById.has(id)){
-    log.critical("poolMeta not found for id {}", [id])
-  }
-  let poolMeta = poolMetaById.get(id)
-  return poolMeta
-}
-
-export function poolFromPile(pile: Address): PoolMeta {
-  if (!poolMetaByPile.has(pile.toHex())) {
-    log.critical("poolMeta not found for pile {}", [pile.toHex()])
-  }
-  let poolMeta = poolMetaByPile.get(pile.toHex())
-  return poolMeta
-}
-
-export function poolFromNftFeed(nftFeed: Address): PoolMeta {
-  if (!poolMetaByNftFeed.has(nftFeed.toHex())) {
-    log.critical("poolMeta not found for nftFeed {}", [nftFeed.toHex()])
-  }
-  let poolMeta = poolMetaByNftFeed.get(nftFeed.toHex())
-  return poolMeta
-}
-
-export function poolFromSeniorTranche(seniorTranche: Address): PoolMeta {
-  if (!poolMetaBySeniorTranche.has(seniorTranche.toHex())) {
-    log.critical("poolMeta not found for seniorTranche {}", [seniorTranche.toHex()])
-  }
-  let poolMeta = poolMetaBySeniorTranche.get(seniorTranche.toHex())
-  return poolMeta
-}
-
-export function poolFromAssessor(assessor: Address): PoolMeta {
-  if (!poolMetaByAssessor.has(assessor.toHex())) {
-    log.critical("poolMeta not found for assessor {}", [assessor.toHex()])
-  }
-  let poolMeta = poolMetaByAssessor.get(assessor.toHex())
+  let poolMeta = poolMetaByIdentifier.get(id)
   return poolMeta
 }
 

--- a/src/poolMetas.spec.ts
+++ b/src/poolMetas.spec.ts
@@ -1,16 +1,20 @@
 import { poolMetaByShelf } from './poolMetas'
 
 describe('poolMeta', () => {
-  test('should retreive poolMeta by shelf', () => {
+  test('should retrieve poolMeta by shelf', () => {
     expect(
       poolMetaByShelf.get("0x454c86ba7e0cbd959cfa76aa2db799f9d7a816e4")
     ).toStrictEqual({
+      shortName: 'ConsolFreight 1',
       id: '0xf8b4ef7781ba8e1b3df6370f71d526d00aad1ee2',
       shelf: '0x454c86ba7e0cbd959cfa76aa2db799f9d7a816e4',
       pile: '0x95b74ef13ff280a89ce3d7bbefc822c210e9939f',
       nftFeed: '0xab351d3e54c975bfa0c2edafb6fab03f94762111',
       assessor: '0x1aba642c1aac9f8da36f7df73eda4ca73e054084',
-      senior: '0x4c1bfb4e3ecbd6200358038e3f560ab6dee9bcb6',
+      seniorTranche: '0x4c1bfb4e3ecbd6200358038e3f560ab6dee9bcb6',
+      juniorTranche: '0xd5c9a6f250fe21d1e39d4a74e0fa3b69192bd889',
+      drop: '0xd5a8c4ba74438aaacf108095e7697f1d295266d8',
+      tin: '0xcebba0db0834610ea34d5e4ccca62df3382b774a',
       networkId: 'mainnet',
       startBlock: 10002000,
       version: 2

--- a/src/poolMetas.spec.ts
+++ b/src/poolMetas.spec.ts
@@ -12,9 +12,9 @@ describe('poolMeta', () => {
       nftFeed: '0xab351d3e54c975bfa0c2edafb6fab03f94762111',
       assessor: '0x1aba642c1aac9f8da36f7df73eda4ca73e054084',
       seniorTranche: '0x4c1bfb4e3ecbd6200358038e3f560ab6dee9bcb6',
-      juniorTranche: '0xd5c9a6f250fe21d1e39d4a74e0fa3b69192bd889',
-      drop: '0xd5a8c4ba74438aaacf108095e7697f1d295266d8',
-      tin: '0xcebba0db0834610ea34d5e4ccca62df3382b774a',
+      juniorTranche: null,
+      drop: null,
+      tin: null,
       networkId: 'mainnet',
       startBlock: 10002000,
       version: 2

--- a/src/poolMetas.spec.ts
+++ b/src/poolMetas.spec.ts
@@ -1,7 +1,7 @@
 import { poolMetaByIdentifier } from './poolMetas'
 
 describe('poolMeta', () => {
-  test('should retrieve poolMeta by shelf', () => {
+  test('should retrieve poolMeta by identifier', () => {
     expect(
       poolMetaByIdentifier.get("0x454c86ba7e0cbd959cfa76aa2db799f9d7a816e4")
     ).toStrictEqual({
@@ -19,7 +19,7 @@ describe('poolMeta', () => {
       startBlock: 10002000,
       version: 2
     })
-
+    
     expect(
       poolMetaByIdentifier.get("non existing")
     ).toStrictEqual(undefined)

--- a/src/poolMetas.spec.ts
+++ b/src/poolMetas.spec.ts
@@ -13,8 +13,8 @@ describe('poolMeta', () => {
       assessor: '0x1aba642c1aac9f8da36f7df73eda4ca73e054084',
       seniorTranche: '0x4c1bfb4e3ecbd6200358038e3f560ab6dee9bcb6',
       juniorTranche: null,
-      drop: null,
-      tin: null,
+      seniorToken: null,
+      juniorToken: null,
       networkId: 'mainnet',
       startBlock: 10002000,
       version: 2

--- a/src/poolMetas.spec.ts
+++ b/src/poolMetas.spec.ts
@@ -1,9 +1,9 @@
-import { poolMetaByShelf } from './poolMetas'
+import { poolMetaByIdentifier } from './poolMetas'
 
 describe('poolMeta', () => {
   test('should retrieve poolMeta by shelf', () => {
     expect(
-      poolMetaByShelf.get("0x454c86ba7e0cbd959cfa76aa2db799f9d7a816e4")
+      poolMetaByIdentifier.get("0x454c86ba7e0cbd959cfa76aa2db799f9d7a816e4")
     ).toStrictEqual({
       shortName: 'ConsolFreight 1',
       id: '0xf8b4ef7781ba8e1b3df6370f71d526d00aad1ee2',
@@ -21,7 +21,7 @@ describe('poolMeta', () => {
     })
 
     expect(
-      poolMetaByShelf.get("non existing")
+      poolMetaByIdentifier.get("non existing")
     ).toStrictEqual(undefined)
   })
 })

--- a/src/poolMetas.ts
+++ b/src/poolMetas.ts
@@ -9,7 +9,10 @@ export class PoolMeta {
   pile: string // pile contract address
   nftFeed: string // NFT or NAV feed contract address
   assessor: string // assessor contract address
+  juniorTranche: string
   seniorTranche: string // senior tranche contract address
+  drop: string
+  tin: string
   networkId: network
   startBlock: number // block where root contract was deployed
   version: version
@@ -29,88 +32,91 @@ export let poolMetas: PoolMeta[] = [
     nftFeed: '0xab351d3e54c975bfa0c2edafb6fab03f94762111',
     assessor: '0x1aba642c1aac9f8da36f7df73eda4ca73e054084',
     seniorTranche: '0x4c1bfb4e3ecbd6200358038e3f560ab6dee9bcb6',
+    juniorTranche: '0xd5c9a6f250fe21d1e39d4a74e0fa3b69192bd889',
+    drop: '0xd5a8c4ba74438aaacf108095e7697f1d295266d8',
+    tin: '0xcebba0db0834610ea34d5e4ccca62df3382b774a',
     networkId: 'mainnet',
     startBlock: 10002000,
     version: 2
   },
-  // PC
-  {
-    shortName: 'Paperchain Pilot',
-    id: '0x90abc0adb789111b4b865fdb3350b14a6e78794e',
-    shelf: '0x3d0e477f328e48daa315aa503a6edf5b67f2d387',
-    pile: '0xa6bf7d7779383f6e078d0969f5b85b391994fced',
-    nftFeed: '0xe231faaea039766fcbb72cbb7d70ce18f0a28b8e',
-    assessor: '0x41203b4c2b497334c01f9ce6f88ab42bd485199d',
-    seniorTranche: '0xf49599f60bad647b9f82b7c5ef7736af13ff89ac',
-    networkId: 'mainnet',
-    startBlock: 10103234,
-    version: 2
-  },
-  // CF2
-  {
-    shortName: 'ConsolFreight 2',
-    id: "0x0b985e7c5811c368528a0fc990455f4b448f7d77",
-    shelf: '0x56ba49ea5f0930d80d14bf077d4bbee0b398bb06',
-    pile: '0x27865916b3e6208b54eb7b3c481b3157e0ac1b0e',
-    nftFeed: '0x7cdc05188b81e2cb11c6332b460233e654d8a3d4',
-    assessor: '0x78bae79c9867bbe393c90cb13401ca1217a2fbee',
-    seniorTranche: '0xae1845a50316fb6e571c569e78338c76d715a899',
-    networkId: 'mainnet',
-    startBlock: 10304149,
-    version: 2
-  },
-  // NS
-  {
-    shortName: 'New Silver 1',
-    id: '0xeb33ab19d17d62950b16e843005fcdda62d5f551',
-    shelf: '0x5fb8479d021e5881a4874fdf15e549355c57b885',
-    pile: '0x1f1ea72b9a1edf799f27ea3a5d18262e92a845a6',
-    nftFeed: '0x3fbcddee1f5efc545828560869353287ec901c04',
-    assessor: '0xfee2b69eddd98397b6cbf816e805ad52bd4407c7',
-    seniorTranche: '0x05791d754ef5788532287de5a730645f2bbcf78f',
-    networkId: 'mainnet',
-    startBlock: 10498700,
-    version: 2
-  },
-  // CF3
-  {
-    shortName: 'ConsolFreight 3',
-    id: '0xe02d16927c7f73e48dd7aef4c86fa9aaedfe8abf',
-    shelf: '0xadafacda038d05e9b20845c66a6955143e3e50a7',
-    pile: '0xa1044556e2cd8e0d3c143fe0f02640727a5a380b',
-    nftFeed: '0xf4846f411e8ab969ef869a5e30dc10a68cf5d2b0',
-    assessor: '0x1f7adb00e86935a8ba83d8d51dc56d8cadf7b1da',
-    seniorTranche: '0x6f038b9987baa1b0acc2b4b96c4050e204acdddd',
-    networkId: 'mainnet',
-    startBlock: 10595436,
-    version: 2
-  },
-  // HTC1
-  {
-    shortName: 'Harbor Trade 1',
-    id: '0xa5caefbaa3902c3567ec2ba650a7ee4b19ea0d28',
-    shelf: '0x406504500ac3efba725f14b6c7ac1e0047ecf520',
-    pile: '0x9c623e8864c9fcd56a2b87826198687ec9d03665',
-    nftFeed: '0x7b01145a8d736207ac46bdb831e7759264b05e6b',
-    assessor: '0xaa298fd9206a4d66346124b6358fc4fc803398e5',
-    seniorTranche: '0x473bd32f890855138ed085582d80099f11ad7767',
-    networkId: 'mainnet',
-    startBlock: 10661341,
-    version: 2
-  },
-  // PC2
-  {
-    shortName: 'Paperchain Series 2',
-    id: '0x23e11b3f2cd3d73f68a4a3af436e2ed3459d0260',
-    shelf: '0x3cf4deecad850a2b09fc2c8ea223943b57d1d4d2',
-    pile: '0x3c3b4b2cc7dbc4409563e74a174ac3c4c4780dfb',
-    nftFeed: '0x67ba167bebed75cbc7bd6b5e9f7cb7749f5a6a50',
-    assessor: '0x6377737c28921fab9497e2a9f30fe8147a3bdfe4',
-    seniorTranche: '0xf2c43699306dab17ec353886272bdfb4f443ad84',
-    networkId: 'mainnet',
-    startBlock: 10783663,
-    version: 2
-  },
+  // // PC
+  // {
+  //   shortName: 'Paperchain Pilot',
+  //   id: '0x90abc0adb789111b4b865fdb3350b14a6e78794e',
+  //   shelf: '0x3d0e477f328e48daa315aa503a6edf5b67f2d387',
+  //   pile: '0xa6bf7d7779383f6e078d0969f5b85b391994fced',
+  //   nftFeed: '0xe231faaea039766fcbb72cbb7d70ce18f0a28b8e',
+  //   assessor: '0x41203b4c2b497334c01f9ce6f88ab42bd485199d',
+  //   seniorTranche: '0xf49599f60bad647b9f82b7c5ef7736af13ff89ac',
+  //   networkId: 'mainnet',
+  //   startBlock: 10103234,
+  //   version: 2
+  // },
+  // // CF2
+  // {
+  //   shortName: 'ConsolFreight 2',
+  //   id: "0x0b985e7c5811c368528a0fc990455f4b448f7d77",
+  //   shelf: '0x56ba49ea5f0930d80d14bf077d4bbee0b398bb06',
+  //   pile: '0x27865916b3e6208b54eb7b3c481b3157e0ac1b0e',
+  //   nftFeed: '0x7cdc05188b81e2cb11c6332b460233e654d8a3d4',
+  //   assessor: '0x78bae79c9867bbe393c90cb13401ca1217a2fbee',
+  //   seniorTranche: '0xae1845a50316fb6e571c569e78338c76d715a899',
+  //   networkId: 'mainnet',
+  //   startBlock: 10304149,
+  //   version: 2
+  // },
+  // // NS
+  // {
+  //   shortName: 'New Silver 1',
+  //   id: '0xeb33ab19d17d62950b16e843005fcdda62d5f551',
+  //   shelf: '0x5fb8479d021e5881a4874fdf15e549355c57b885',
+  //   pile: '0x1f1ea72b9a1edf799f27ea3a5d18262e92a845a6',
+  //   nftFeed: '0x3fbcddee1f5efc545828560869353287ec901c04',
+  //   assessor: '0xfee2b69eddd98397b6cbf816e805ad52bd4407c7',
+  //   seniorTranche: '0x05791d754ef5788532287de5a730645f2bbcf78f',
+  //   networkId: 'mainnet',
+  //   startBlock: 10498700,
+  //   version: 2
+  // },
+  // // CF3
+  // {
+  //   shortName: 'ConsolFreight 3',
+  //   id: '0xe02d16927c7f73e48dd7aef4c86fa9aaedfe8abf',
+  //   shelf: '0xadafacda038d05e9b20845c66a6955143e3e50a7',
+  //   pile: '0xa1044556e2cd8e0d3c143fe0f02640727a5a380b',
+  //   nftFeed: '0xf4846f411e8ab969ef869a5e30dc10a68cf5d2b0',
+  //   assessor: '0x1f7adb00e86935a8ba83d8d51dc56d8cadf7b1da',
+  //   seniorTranche: '0x6f038b9987baa1b0acc2b4b96c4050e204acdddd',
+  //   networkId: 'mainnet',
+  //   startBlock: 10595436,
+  //   version: 2
+  // },
+  // // HTC1
+  // {
+  //   shortName: 'Harbor Trade 1',
+  //   id: '0xa5caefbaa3902c3567ec2ba650a7ee4b19ea0d28',
+  //   shelf: '0x406504500ac3efba725f14b6c7ac1e0047ecf520',
+  //   pile: '0x9c623e8864c9fcd56a2b87826198687ec9d03665',
+  //   nftFeed: '0x7b01145a8d736207ac46bdb831e7759264b05e6b',
+  //   assessor: '0xaa298fd9206a4d66346124b6358fc4fc803398e5',
+  //   seniorTranche: '0x473bd32f890855138ed085582d80099f11ad7767',
+  //   networkId: 'mainnet',
+  //   startBlock: 10661341,
+  //   version: 2
+  // },
+  // // PC2
+  // {
+  //   shortName: 'Paperchain Series 2',
+  //   id: '0x23e11b3f2cd3d73f68a4a3af436e2ed3459d0260',
+  //   shelf: '0x3cf4deecad850a2b09fc2c8ea223943b57d1d4d2',
+  //   pile: '0x3c3b4b2cc7dbc4409563e74a174ac3c4c4780dfb',
+  //   nftFeed: '0x67ba167bebed75cbc7bd6b5e9f7cb7749f5a6a50',
+  //   assessor: '0x6377737c28921fab9497e2a9f30fe8147a3bdfe4',
+  //   seniorTranche: '0xf2c43699306dab17ec353886272bdfb4f443ad84',
+  //   networkId: 'mainnet',
+  //   startBlock: 10783663,
+  //   version: 2
+  // },
   // CF4
   {
     shortName: 'ConsolFreight 4',
@@ -119,54 +125,69 @@ export let poolMetas: PoolMeta[] = [
     pile: '0x3fc72da5545e2ab6202d81fbeb1c8273be95068c',
     nftFeed: '0x69504da6b2cd8320b9a62f3aed410a298d3e7ac6',
     assessor: '0x6aaf2ee5b2b62fb9e29e021a1bf3b381454d900a',
+    juniorTranche: '0x145d6256e20cd115eda44eb9258a3bc13c2a86fc',
     seniorTranche: '0xb101ed16ad86cb5cc92dadc357ad994ab6c663a5',
+    drop: '0x5b2f0521875b188c0afc925b1598e1ff246f9306',
+    tin: '0x05dd145aa26dbdcc7774e4118e34bb67c64661c6',
     networkId: 'mainnet',
     startBlock: 11063000,
     version: 3
   },
 
-  // Mainnet staging
-  {
-    shortName: 'Mainnet Staging',
-    id: '0x05597dd9b8e1d4fdb44eb69d20bc3a2feef605e8',
-    shelf: '0x7ca150514c9b17c1e343d420d66238a299f80070',
-    pile: '0xbef9e6b821c7a54797f0e73cf0d72a140b6db378',
-    nftFeed: '0x865963b74b87387106bf12b01a097b3801f906fb',
-    assessor: '0x9f5d1cce788d9383a5db8110d2f47d58011ff230',
-    seniorTranche: '0x3a448226a26c072a6554a1786a2e29f70c96d8b6',
-    networkId: 'mainnet',
-    startBlock: 9993512,
-    version: 2
-  },
+  // // Mainnet staging
+  // {
+  //   shortName: 'Mainnet Staging',
+  //   id: '0x05597dd9b8e1d4fdb44eb69d20bc3a2feef605e8',
+  //   shelf: '0x7ca150514c9b17c1e343d420d66238a299f80070',
+  //   pile: '0xbef9e6b821c7a54797f0e73cf0d72a140b6db378',
+  //   nftFeed: '0x865963b74b87387106bf12b01a097b3801f906fb',
+  //   assessor: '0x9f5d1cce788d9383a5db8110d2f47d58011ff230',
+  //   seniorTranche: '0x3a448226a26c072a6554a1786a2e29f70c96d8b6',
+  //   networkId: 'mainnet',
+  //   startBlock: 9993512,
+  //   version: 2
+  // },
 
-  // Kovan Static NAV Pool 1
-  {
-    shortName: 'Kovan Static 1',
-    id: '0x6f3d561b203c69cdee90f2870ea58e5a7da460b2',
-    shelf: '0x838faae94ed562a9597634d558987c7b5acd6b84',
-    pile: '0x7a5d7331b7229014d0469de5cdd369d119c7e4de',
-    nftFeed: '0x66390b34772c8e3665aba884b18c6365cef091b8',
-    assessor: '0xb99b95e37ec8bc796fe8a18a8a61a3e36b007372',
-    seniorTranche: '0x33f521cb1daeb96b1f7a99260ed6c2c68645fd97',
-    networkId: 'kovan',
-    startBlock: 20911916,
-    version: 2
-  },
+  // // Kovan Static NAV Pool 1
+  // {
+  //   shortName: 'Kovan Static 1',
+  //   id: '0x6f3d561b203c69cdee90f2870ea58e5a7da460b2',
+  //   shelf: '0x838faae94ed562a9597634d558987c7b5acd6b84',
+  //   pile: '0x7a5d7331b7229014d0469de5cdd369d119c7e4de',
+  //   nftFeed: '0x66390b34772c8e3665aba884b18c6365cef091b8',
+  //   assessor: '0xb99b95e37ec8bc796fe8a18a8a61a3e36b007372',
+  //   seniorTranche: '0x33f521cb1daeb96b1f7a99260ed6c2c68645fd97',
+  //   networkId: 'kovan',
+  //   startBlock: 20911916,
+  //   version: 2
+  // },
 
-  // Kovan Revolving Pool 1
-  {
-    shortName: 'Kovan Revolving 1',
-    id: '0xc4084221fb5d0f28f817c795435c2d17eab6c389',
-    shelf: '0xc7e4515fb85bb5ba1a76a8624e2ab563b4dea8af',
-    pile: '0x82ee3f4b872d2a53b7b5cf2bd88ebc8736914407',
-    nftFeed: '0x677b85998f15921982b1548763f01ac6c265b8eb',
-    assessor: '0x8b80927fca02566c29728c4a620c161f63116953',
-    seniorTranche: '0x88ad5b21a01d838b15619f36f88b618410797b95',
-    networkId: 'kovan',
-    startBlock: 21406294,
-    version: 3
-  },
+  // // Kovan Revolving Pool 1
+  // {
+  //   shortName: 'Kovan Revolving 1',
+  //   id: '0xc4084221fb5d0f28f817c795435c2d17eab6c389',
+  //   shelf: '0xc7e4515fb85bb5ba1a76a8624e2ab563b4dea8af',
+  //   pile: '0x82ee3f4b872d2a53b7b5cf2bd88ebc8736914407',
+  //   nftFeed: '0x677b85998f15921982b1548763f01ac6c265b8eb',
+  //   assessor: '0x8b80927fca02566c29728c4a620c161f63116953',
+  //   seniorTranche: '0x88ad5b21a01d838b15619f36f88b618410797b95',
+  //   networkId: 'kovan',
+  //   startBlock: 21406294,
+  //   version: 3
+  // },
 ]
+
+export let poolMetaByAddress = new Map<string, PoolMeta>()
+for (let i = 0; i < poolMetas.length; i++) {
+  poolMetaByAddress.set(poolMetas[i].id, poolMetas[i])
+  poolMetaByAddress.set(poolMetas[i].shelf, poolMetas[i])
+  poolMetaByAddress.set(poolMetas[i].pile, poolMetas[i])
+  poolMetaByAddress.set(poolMetas[i].nftFeed, poolMetas[i])
+  poolMetaByAddress.set(poolMetas[i].seniorTranche, poolMetas[i])
+  poolMetaByAddress.set(poolMetas[i].juniorTranche, poolMetas[i])
+  poolMetaByAddress.set(poolMetas[i].drop, poolMetas[i])
+  poolMetaByAddress.set(poolMetas[i].tin, poolMetas[i])
+}
 
 // lookup that contains the rootId indexed by shelf
 export let poolMetaById = new Map<string, PoolMeta>()

--- a/src/poolMetas.ts
+++ b/src/poolMetas.ts
@@ -32,91 +32,109 @@ export let poolMetas: PoolMeta[] = [
     nftFeed: '0xab351d3e54c975bfa0c2edafb6fab03f94762111',
     assessor: '0x1aba642c1aac9f8da36f7df73eda4ca73e054084',
     seniorTranche: '0x4c1bfb4e3ecbd6200358038e3f560ab6dee9bcb6',
-    juniorTranche: '0xd5c9a6f250fe21d1e39d4a74e0fa3b69192bd889',
-    drop: '0xd5a8c4ba74438aaacf108095e7697f1d295266d8',
-    tin: '0xcebba0db0834610ea34d5e4ccca62df3382b774a',
+    juniorTranche: null,
+    drop: null,
+    tin: null,
     networkId: 'mainnet',
     startBlock: 10002000,
     version: 2
   },
-  // // PC
-  // {
-  //   shortName: 'Paperchain Pilot',
-  //   id: '0x90abc0adb789111b4b865fdb3350b14a6e78794e',
-  //   shelf: '0x3d0e477f328e48daa315aa503a6edf5b67f2d387',
-  //   pile: '0xa6bf7d7779383f6e078d0969f5b85b391994fced',
-  //   nftFeed: '0xe231faaea039766fcbb72cbb7d70ce18f0a28b8e',
-  //   assessor: '0x41203b4c2b497334c01f9ce6f88ab42bd485199d',
-  //   seniorTranche: '0xf49599f60bad647b9f82b7c5ef7736af13ff89ac',
-  //   networkId: 'mainnet',
-  //   startBlock: 10103234,
-  //   version: 2
-  // },
-  // // CF2
-  // {
-  //   shortName: 'ConsolFreight 2',
-  //   id: "0x0b985e7c5811c368528a0fc990455f4b448f7d77",
-  //   shelf: '0x56ba49ea5f0930d80d14bf077d4bbee0b398bb06',
-  //   pile: '0x27865916b3e6208b54eb7b3c481b3157e0ac1b0e',
-  //   nftFeed: '0x7cdc05188b81e2cb11c6332b460233e654d8a3d4',
-  //   assessor: '0x78bae79c9867bbe393c90cb13401ca1217a2fbee',
-  //   seniorTranche: '0xae1845a50316fb6e571c569e78338c76d715a899',
-  //   networkId: 'mainnet',
-  //   startBlock: 10304149,
-  //   version: 2
-  // },
-  // // NS
-  // {
-  //   shortName: 'New Silver 1',
-  //   id: '0xeb33ab19d17d62950b16e843005fcdda62d5f551',
-  //   shelf: '0x5fb8479d021e5881a4874fdf15e549355c57b885',
-  //   pile: '0x1f1ea72b9a1edf799f27ea3a5d18262e92a845a6',
-  //   nftFeed: '0x3fbcddee1f5efc545828560869353287ec901c04',
-  //   assessor: '0xfee2b69eddd98397b6cbf816e805ad52bd4407c7',
-  //   seniorTranche: '0x05791d754ef5788532287de5a730645f2bbcf78f',
-  //   networkId: 'mainnet',
-  //   startBlock: 10498700,
-  //   version: 2
-  // },
-  // // CF3
-  // {
-  //   shortName: 'ConsolFreight 3',
-  //   id: '0xe02d16927c7f73e48dd7aef4c86fa9aaedfe8abf',
-  //   shelf: '0xadafacda038d05e9b20845c66a6955143e3e50a7',
-  //   pile: '0xa1044556e2cd8e0d3c143fe0f02640727a5a380b',
-  //   nftFeed: '0xf4846f411e8ab969ef869a5e30dc10a68cf5d2b0',
-  //   assessor: '0x1f7adb00e86935a8ba83d8d51dc56d8cadf7b1da',
-  //   seniorTranche: '0x6f038b9987baa1b0acc2b4b96c4050e204acdddd',
-  //   networkId: 'mainnet',
-  //   startBlock: 10595436,
-  //   version: 2
-  // },
-  // // HTC1
-  // {
-  //   shortName: 'Harbor Trade 1',
-  //   id: '0xa5caefbaa3902c3567ec2ba650a7ee4b19ea0d28',
-  //   shelf: '0x406504500ac3efba725f14b6c7ac1e0047ecf520',
-  //   pile: '0x9c623e8864c9fcd56a2b87826198687ec9d03665',
-  //   nftFeed: '0x7b01145a8d736207ac46bdb831e7759264b05e6b',
-  //   assessor: '0xaa298fd9206a4d66346124b6358fc4fc803398e5',
-  //   seniorTranche: '0x473bd32f890855138ed085582d80099f11ad7767',
-  //   networkId: 'mainnet',
-  //   startBlock: 10661341,
-  //   version: 2
-  // },
-  // // PC2
-  // {
-  //   shortName: 'Paperchain Series 2',
-  //   id: '0x23e11b3f2cd3d73f68a4a3af436e2ed3459d0260',
-  //   shelf: '0x3cf4deecad850a2b09fc2c8ea223943b57d1d4d2',
-  //   pile: '0x3c3b4b2cc7dbc4409563e74a174ac3c4c4780dfb',
-  //   nftFeed: '0x67ba167bebed75cbc7bd6b5e9f7cb7749f5a6a50',
-  //   assessor: '0x6377737c28921fab9497e2a9f30fe8147a3bdfe4',
-  //   seniorTranche: '0xf2c43699306dab17ec353886272bdfb4f443ad84',
-  //   networkId: 'mainnet',
-  //   startBlock: 10783663,
-  //   version: 2
-  // },
+  // PC
+  {
+    shortName: 'Paperchain Pilot',
+    id: '0x90abc0adb789111b4b865fdb3350b14a6e78794e',
+    shelf: '0x3d0e477f328e48daa315aa503a6edf5b67f2d387',
+    pile: '0xa6bf7d7779383f6e078d0969f5b85b391994fced',
+    nftFeed: '0xe231faaea039766fcbb72cbb7d70ce18f0a28b8e',
+    assessor: '0x41203b4c2b497334c01f9ce6f88ab42bd485199d',
+    seniorTranche: '0xf49599f60bad647b9f82b7c5ef7736af13ff89ac',
+    juniorTranche: null,
+    drop: null,
+    tin: null,
+    networkId: 'mainnet',
+    startBlock: 10103234,
+    version: 2
+  },
+  // CF2
+  {
+    shortName: 'ConsolFreight 2',
+    id: "0x0b985e7c5811c368528a0fc990455f4b448f7d77",
+    shelf: '0x56ba49ea5f0930d80d14bf077d4bbee0b398bb06',
+    pile: '0x27865916b3e6208b54eb7b3c481b3157e0ac1b0e',
+    nftFeed: '0x7cdc05188b81e2cb11c6332b460233e654d8a3d4',
+    assessor: '0x78bae79c9867bbe393c90cb13401ca1217a2fbee',
+    seniorTranche: '0xae1845a50316fb6e571c569e78338c76d715a899',
+    juniorTranche: null,
+    drop: null,
+    tin: null,
+    networkId: 'mainnet',
+    startBlock: 10304149,
+    version: 2
+  },
+  // NS
+  {
+    shortName: 'New Silver 1',
+    id: '0xeb33ab19d17d62950b16e843005fcdda62d5f551',
+    shelf: '0x5fb8479d021e5881a4874fdf15e549355c57b885',
+    pile: '0x1f1ea72b9a1edf799f27ea3a5d18262e92a845a6',
+    nftFeed: '0x3fbcddee1f5efc545828560869353287ec901c04',
+    assessor: '0xfee2b69eddd98397b6cbf816e805ad52bd4407c7',
+    seniorTranche: '0x05791d754ef5788532287de5a730645f2bbcf78f',
+    juniorTranche: null,
+    drop: null,
+    tin: null,
+    networkId: 'mainnet',
+    startBlock: 10498700,
+    version: 2
+  },
+  // CF3
+  {
+    shortName: 'ConsolFreight 3',
+    id: '0xe02d16927c7f73e48dd7aef4c86fa9aaedfe8abf',
+    shelf: '0xadafacda038d05e9b20845c66a6955143e3e50a7',
+    pile: '0xa1044556e2cd8e0d3c143fe0f02640727a5a380b',
+    nftFeed: '0xf4846f411e8ab969ef869a5e30dc10a68cf5d2b0',
+    assessor: '0x1f7adb00e86935a8ba83d8d51dc56d8cadf7b1da',
+    seniorTranche: '0x6f038b9987baa1b0acc2b4b96c4050e204acdddd',
+    juniorTranche: null,
+    drop: null,
+    tin: null,
+    networkId: 'mainnet',
+    startBlock: 10595436,
+    version: 2
+  },
+  // HTC1
+  {
+    shortName: 'Harbor Trade 1',
+    id: '0xa5caefbaa3902c3567ec2ba650a7ee4b19ea0d28',
+    shelf: '0x406504500ac3efba725f14b6c7ac1e0047ecf520',
+    pile: '0x9c623e8864c9fcd56a2b87826198687ec9d03665',
+    nftFeed: '0x7b01145a8d736207ac46bdb831e7759264b05e6b',
+    assessor: '0xaa298fd9206a4d66346124b6358fc4fc803398e5',
+    seniorTranche: '0x473bd32f890855138ed085582d80099f11ad7767',
+    juniorTranche: null,
+    drop: null,
+    tin: null,
+    networkId: 'mainnet',
+    startBlock: 10661341,
+    version: 2
+  },
+  // PC2
+  {
+    shortName: 'Paperchain Series 2',
+    id: '0x23e11b3f2cd3d73f68a4a3af436e2ed3459d0260',
+    shelf: '0x3cf4deecad850a2b09fc2c8ea223943b57d1d4d2',
+    pile: '0x3c3b4b2cc7dbc4409563e74a174ac3c4c4780dfb',
+    nftFeed: '0x67ba167bebed75cbc7bd6b5e9f7cb7749f5a6a50',
+    assessor: '0x6377737c28921fab9497e2a9f30fe8147a3bdfe4',
+    seniorTranche: '0xf2c43699306dab17ec353886272bdfb4f443ad84',
+    juniorTranche: null,
+    drop: null,
+    tin: null,
+    networkId: 'mainnet',
+    startBlock: 10783663,
+    version: 2
+  },
   // CF4
   {
     shortName: 'ConsolFreight 4',
@@ -134,47 +152,56 @@ export let poolMetas: PoolMeta[] = [
     version: 3
   },
 
-  // // Mainnet staging
-  // {
-  //   shortName: 'Mainnet Staging',
-  //   id: '0x05597dd9b8e1d4fdb44eb69d20bc3a2feef605e8',
-  //   shelf: '0x7ca150514c9b17c1e343d420d66238a299f80070',
-  //   pile: '0xbef9e6b821c7a54797f0e73cf0d72a140b6db378',
-  //   nftFeed: '0x865963b74b87387106bf12b01a097b3801f906fb',
-  //   assessor: '0x9f5d1cce788d9383a5db8110d2f47d58011ff230',
-  //   seniorTranche: '0x3a448226a26c072a6554a1786a2e29f70c96d8b6',
-  //   networkId: 'mainnet',
-  //   startBlock: 9993512,
-  //   version: 2
-  // },
+  // Mainnet staging
+  {
+    shortName: 'Mainnet Staging',
+    id: '0x05597dd9b8e1d4fdb44eb69d20bc3a2feef605e8',
+    shelf: '0x7ca150514c9b17c1e343d420d66238a299f80070',
+    pile: '0xbef9e6b821c7a54797f0e73cf0d72a140b6db378',
+    nftFeed: '0x865963b74b87387106bf12b01a097b3801f906fb',
+    assessor: '0x9f5d1cce788d9383a5db8110d2f47d58011ff230',
+    seniorTranche: '0x3a448226a26c072a6554a1786a2e29f70c96d8b6',
+    juniorTranche: null,
+    drop: null,
+    tin: null,
+    networkId: 'mainnet',
+    startBlock: 9993512,
+    version: 2
+  },
 
-  // // Kovan Static NAV Pool 1
-  // {
-  //   shortName: 'Kovan Static 1',
-  //   id: '0x6f3d561b203c69cdee90f2870ea58e5a7da460b2',
-  //   shelf: '0x838faae94ed562a9597634d558987c7b5acd6b84',
-  //   pile: '0x7a5d7331b7229014d0469de5cdd369d119c7e4de',
-  //   nftFeed: '0x66390b34772c8e3665aba884b18c6365cef091b8',
-  //   assessor: '0xb99b95e37ec8bc796fe8a18a8a61a3e36b007372',
-  //   seniorTranche: '0x33f521cb1daeb96b1f7a99260ed6c2c68645fd97',
-  //   networkId: 'kovan',
-  //   startBlock: 20911916,
-  //   version: 2
-  // },
+  // Kovan Static NAV Pool 1
+  {
+    shortName: 'Kovan Static 1',
+    id: '0x6f3d561b203c69cdee90f2870ea58e5a7da460b2',
+    shelf: '0x838faae94ed562a9597634d558987c7b5acd6b84',
+    pile: '0x7a5d7331b7229014d0469de5cdd369d119c7e4de',
+    nftFeed: '0x66390b34772c8e3665aba884b18c6365cef091b8',
+    assessor: '0xb99b95e37ec8bc796fe8a18a8a61a3e36b007372',
+    seniorTranche: '0x33f521cb1daeb96b1f7a99260ed6c2c68645fd97',
+    juniorTranche: null,
+    drop: null,
+    tin: null,
+    networkId: 'kovan',
+    startBlock: 20911916,
+    version: 2
+  },
 
-  // // Kovan Revolving Pool 1
-  // {
-  //   shortName: 'Kovan Revolving 1',
-  //   id: '0xc4084221fb5d0f28f817c795435c2d17eab6c389',
-  //   shelf: '0xc7e4515fb85bb5ba1a76a8624e2ab563b4dea8af',
-  //   pile: '0x82ee3f4b872d2a53b7b5cf2bd88ebc8736914407',
-  //   nftFeed: '0x677b85998f15921982b1548763f01ac6c265b8eb',
-  //   assessor: '0x8b80927fca02566c29728c4a620c161f63116953',
-  //   seniorTranche: '0x88ad5b21a01d838b15619f36f88b618410797b95',
-  //   networkId: 'kovan',
-  //   startBlock: 21406294,
-  //   version: 3
-  // },
+  // Kovan Revolving Pool 1
+  {
+    shortName: 'Kovan Revolving 1',
+    id: '0xc4084221fb5d0f28f817c795435c2d17eab6c389',
+    shelf: '0xc7e4515fb85bb5ba1a76a8624e2ab563b4dea8af',
+    pile: '0x82ee3f4b872d2a53b7b5cf2bd88ebc8736914407',
+    nftFeed: '0x677b85998f15921982b1548763f01ac6c265b8eb',
+    assessor: '0x8b80927fca02566c29728c4a620c161f63116953',
+    seniorTranche: '0x88ad5b21a01d838b15619f36f88b618410797b95',
+    juniorTranche: null,
+    drop: null,
+    tin: null,
+    networkId: 'kovan',
+    startBlock: 21406294,
+    version: 3
+  },
 ]
 
 export let poolMetaByAddress = new Map<string, PoolMeta>()

--- a/src/poolMetas.ts
+++ b/src/poolMetas.ts
@@ -11,8 +11,8 @@ export class PoolMeta {
   assessor: string // assessor contract address
   juniorTranche: string
   seniorTranche: string // senior tranche contract address
-  drop: string
-  tin: string
+  seniorToken: string
+  juniorToken: string
   networkId: network
   startBlock: number // block where root contract was deployed
   version: version
@@ -33,8 +33,8 @@ export let poolMetas: PoolMeta[] = [
     assessor: '0x1aba642c1aac9f8da36f7df73eda4ca73e054084',
     seniorTranche: '0x4c1bfb4e3ecbd6200358038e3f560ab6dee9bcb6',
     juniorTranche: null,
-    drop: null,
-    tin: null,
+    seniorToken: null,
+    juniorToken: null,
     networkId: 'mainnet',
     startBlock: 10002000,
     version: 2
@@ -49,8 +49,8 @@ export let poolMetas: PoolMeta[] = [
     assessor: '0x41203b4c2b497334c01f9ce6f88ab42bd485199d',
     seniorTranche: '0xf49599f60bad647b9f82b7c5ef7736af13ff89ac',
     juniorTranche: null,
-    drop: null,
-    tin: null,
+    seniorToken: null,
+    juniorToken: null,
     networkId: 'mainnet',
     startBlock: 10103234,
     version: 2
@@ -65,8 +65,8 @@ export let poolMetas: PoolMeta[] = [
     assessor: '0x78bae79c9867bbe393c90cb13401ca1217a2fbee',
     seniorTranche: '0xae1845a50316fb6e571c569e78338c76d715a899',
     juniorTranche: null,
-    drop: null,
-    tin: null,
+    seniorToken: null,
+    juniorToken: null,
     networkId: 'mainnet',
     startBlock: 10304149,
     version: 2
@@ -81,8 +81,8 @@ export let poolMetas: PoolMeta[] = [
     assessor: '0xfee2b69eddd98397b6cbf816e805ad52bd4407c7',
     seniorTranche: '0x05791d754ef5788532287de5a730645f2bbcf78f',
     juniorTranche: null,
-    drop: null,
-    tin: null,
+    seniorToken: null,
+    juniorToken: null,
     networkId: 'mainnet',
     startBlock: 10498700,
     version: 2
@@ -97,8 +97,8 @@ export let poolMetas: PoolMeta[] = [
     assessor: '0x1f7adb00e86935a8ba83d8d51dc56d8cadf7b1da',
     seniorTranche: '0x6f038b9987baa1b0acc2b4b96c4050e204acdddd',
     juniorTranche: null,
-    drop: null,
-    tin: null,
+    seniorToken: null,
+    juniorToken: null,
     networkId: 'mainnet',
     startBlock: 10595436,
     version: 2
@@ -113,8 +113,8 @@ export let poolMetas: PoolMeta[] = [
     assessor: '0xaa298fd9206a4d66346124b6358fc4fc803398e5',
     seniorTranche: '0x473bd32f890855138ed085582d80099f11ad7767',
     juniorTranche: null,
-    drop: null,
-    tin: null,
+    seniorToken: null,
+    juniorToken: null,
     networkId: 'mainnet',
     startBlock: 10661341,
     version: 2
@@ -129,8 +129,8 @@ export let poolMetas: PoolMeta[] = [
     assessor: '0x6377737c28921fab9497e2a9f30fe8147a3bdfe4',
     seniorTranche: '0xf2c43699306dab17ec353886272bdfb4f443ad84',
     juniorTranche: null,
-    drop: null,
-    tin: null,
+    seniorToken: null,
+    juniorToken: null,
     networkId: 'mainnet',
     startBlock: 10783663,
     version: 2
@@ -145,8 +145,8 @@ export let poolMetas: PoolMeta[] = [
     assessor: '0x6aaf2ee5b2b62fb9e29e021a1bf3b381454d900a',
     juniorTranche: '0x145d6256e20cd115eda44eb9258a3bc13c2a86fc',
     seniorTranche: '0xb101ed16ad86cb5cc92dadc357ad994ab6c663a5',
-    drop: '0x5b2f0521875b188c0afc925b1598e1ff246f9306',
-    tin: '0x05dd145aa26dbdcc7774e4118e34bb67c64661c6',
+    seniorToken: '0x5b2f0521875b188c0afc925b1598e1ff246f9306',
+    juniorToken: '0x05dd145aa26dbdcc7774e4118e34bb67c64661c6',
     networkId: 'mainnet',
     startBlock: 11063000,
     version: 3
@@ -162,8 +162,8 @@ export let poolMetas: PoolMeta[] = [
     assessor: '0x9f5d1cce788d9383a5db8110d2f47d58011ff230',
     seniorTranche: '0x3a448226a26c072a6554a1786a2e29f70c96d8b6',
     juniorTranche: null,
-    drop: null,
-    tin: null,
+    seniorToken: null,
+    juniorToken: null,
     networkId: 'mainnet',
     startBlock: 9993512,
     version: 2
@@ -179,8 +179,8 @@ export let poolMetas: PoolMeta[] = [
     assessor: '0xb99b95e37ec8bc796fe8a18a8a61a3e36b007372',
     seniorTranche: '0x33f521cb1daeb96b1f7a99260ed6c2c68645fd97',
     juniorTranche: null,
-    drop: null,
-    tin: null,
+    seniorToken: null,
+    juniorToken: null,
     networkId: 'kovan',
     startBlock: 20911916,
     version: 2
@@ -196,8 +196,8 @@ export let poolMetas: PoolMeta[] = [
     assessor: '0x8b80927fca02566c29728c4a620c161f63116953',
     seniorTranche: '0x88ad5b21a01d838b15619f36f88b618410797b95',
     juniorTranche: null,
-    drop: null,
-    tin: null,
+    seniorToken: null,
+    juniorToken: null,
     networkId: 'kovan',
     startBlock: 21406294,
     version: 3
@@ -212,8 +212,8 @@ for (let i = 0; i < poolMetas.length; i++) {
   poolMetaByAddress.set(poolMetas[i].nftFeed, poolMetas[i])
   poolMetaByAddress.set(poolMetas[i].seniorTranche, poolMetas[i])
   poolMetaByAddress.set(poolMetas[i].juniorTranche, poolMetas[i])
-  poolMetaByAddress.set(poolMetas[i].drop, poolMetas[i])
-  poolMetaByAddress.set(poolMetas[i].tin, poolMetas[i])
+  poolMetaByAddress.set(poolMetas[i].seniorToken, poolMetas[i])
+  poolMetaByAddress.set(poolMetas[i].juniorToken, poolMetas[i])
 }
 
 // lookup that contains the rootId indexed by shelf

--- a/src/poolMetas.ts
+++ b/src/poolMetas.ts
@@ -211,6 +211,7 @@ for (let i = 0; i < poolMetas.length; i++) {
   poolMetaByIdentifier.set(poolMetas[i].shelf, poolMetas[i])
   poolMetaByIdentifier.set(poolMetas[i].pile, poolMetas[i])
   poolMetaByIdentifier.set(poolMetas[i].nftFeed, poolMetas[i])
+  poolMetaByIdentifier.set(poolMetas[i].assessor, poolMetas[i])
   poolMetaByIdentifier.set(poolMetas[i].seniorTranche, poolMetas[i])
   poolMetaByIdentifier.set(poolMetas[i].juniorTranche, poolMetas[i])
   poolMetaByIdentifier.set(poolMetas[i].seniorToken, poolMetas[i])

--- a/src/poolMetas.ts
+++ b/src/poolMetas.ts
@@ -204,52 +204,17 @@ export let poolMetas: PoolMeta[] = [
   },
 ]
 
-export let poolMetaByAddress = new Map<string, PoolMeta>()
+// lookup that contains the pool by associated address or poolId
+export let poolMetaByIdentifier = new Map<string, PoolMeta>()
 for (let i = 0; i < poolMetas.length; i++) {
-  poolMetaByAddress.set(poolMetas[i].id, poolMetas[i])
-  poolMetaByAddress.set(poolMetas[i].shelf, poolMetas[i])
-  poolMetaByAddress.set(poolMetas[i].pile, poolMetas[i])
-  poolMetaByAddress.set(poolMetas[i].nftFeed, poolMetas[i])
-  poolMetaByAddress.set(poolMetas[i].seniorTranche, poolMetas[i])
-  poolMetaByAddress.set(poolMetas[i].juniorTranche, poolMetas[i])
-  poolMetaByAddress.set(poolMetas[i].seniorToken, poolMetas[i])
-  poolMetaByAddress.set(poolMetas[i].juniorToken, poolMetas[i])
-}
-
-// lookup that contains the rootId indexed by shelf
-export let poolMetaById = new Map<string, PoolMeta>()
-for (let i = 0; i < poolMetas.length; i++) {
-  poolMetaById.set(poolMetas[i].id, poolMetas[i])
-}
-
-// lookup that contains the pool indexed by shelf
-export let poolMetaByShelf = new Map<string, PoolMeta>()
-for (let i = 0; i < poolMetas.length; i++) {
-  poolMetaByShelf.set(poolMetas[i].shelf, poolMetas[i])
-}
-
-// lookup that contains the pool indexed by pile
-export let poolMetaByPile = new Map<string, PoolMeta>()
-for (let i = 0; i < poolMetas.length; i++) {
-  poolMetaByPile.set(poolMetas[i].pile, poolMetas[i])
-}
-
-// lookup that contains the pool indexed by nftFeed
-export let poolMetaByNftFeed = new Map<string, PoolMeta>()
-for (let i = 0; i < poolMetas.length; i++) {
-  poolMetaByNftFeed.set(poolMetas[i].nftFeed, poolMetas[i])
-}
-
-// lookup that contains the pool indexed by seniorTranche
-export let poolMetaBySeniorTranche = new Map<string, PoolMeta>()
-for (let i = 0; i < poolMetas.length; i++) {
-  poolMetaBySeniorTranche.set(poolMetas[i].seniorTranche, poolMetas[i])
-}
-
-// lookup that contains the pool indexed by assessor
-export let poolMetaByAssessor = new Map<string, PoolMeta>()
-for (let i = 0; i < poolMetas.length; i++) {
-  poolMetaByAssessor.set(poolMetas[i].assessor, poolMetas[i])
+  poolMetaByIdentifier.set(poolMetas[i].id, poolMetas[i])
+  poolMetaByIdentifier.set(poolMetas[i].shelf, poolMetas[i])
+  poolMetaByIdentifier.set(poolMetas[i].pile, poolMetas[i])
+  poolMetaByIdentifier.set(poolMetas[i].nftFeed, poolMetas[i])
+  poolMetaByIdentifier.set(poolMetas[i].seniorTranche, poolMetas[i])
+  poolMetaByIdentifier.set(poolMetas[i].juniorTranche, poolMetas[i])
+  poolMetaByIdentifier.set(poolMetas[i].seniorToken, poolMetas[i])
+  poolMetaByIdentifier.set(poolMetas[i].juniorToken, poolMetas[i])
 }
 
 export let poolStartBlocks = new Map<number, boolean>()

--- a/src/transferUtil.ts
+++ b/src/transferUtil.ts
@@ -1,0 +1,81 @@
+import { BigInt } from '@graphprotocol/graph-ts';
+import { Account, ERC20Transfer, Token, TokenBalance } from '../generated/schema'
+import { Transfer as TransferEvent } from '../generated/Block/ERC20'
+import { PoolMeta } from './poolMetas'
+
+const zero = BigInt.fromI32(0)
+
+export function createAccount(address: string): Account {
+    let account = new Account(address)
+    account.currentActiveInvestmentAmount = zero
+    account.save()
+    return account;
+}
+
+export function createToken(event: TransferEvent): Token {
+    let token = new Token(event.address.toHex())
+    token.save()
+    return token;
+}
+
+export function createERC20Transfer(id: string, event: TransferEvent, poolMeta: PoolMeta): ERC20Transfer {    
+    let transfer = new ERC20Transfer(id)
+    transfer.transaction = event.transaction.hash.toHex()
+    transfer.token = event.address.toHex()
+    transfer.from = event.params.src.toHex()
+    transfer.to = event.params.dst.toHex()
+    transfer.amount = event.params.wad
+    transfer.pool = poolMeta.id
+    transfer.save()
+    return transfer;
+}
+
+export function createTokenBalance(id: string, event: TransferEvent, owner: string): TokenBalance {
+    let tokenBalance = new TokenBalance(id)
+    tokenBalance.owner = owner
+    tokenBalance.balance = zero
+    tokenBalance.value = zero
+    tokenBalance.token = event.address.toHex()
+    tokenBalance.save()
+    return tokenBalance
+}
+
+export function loadOrCreateTokenBalanceDst(event: TransferEvent): TokenBalance { 
+    let tokenBalanceDstId = event.params.dst.toHex() + event.address.toHex()
+    let tokenBalanceDst = TokenBalance.load(tokenBalanceDstId)
+    if (tokenBalanceDst == null) {
+        tokenBalanceDst = createTokenBalance(tokenBalanceDstId, event, event.params.dst.toHex())
+    }
+    tokenBalanceDst.balance = tokenBalanceDst.balance.plus(event.params.wad)
+    tokenBalanceDst.save()
+    return <TokenBalance>tokenBalanceDst
+}
+
+export function loadOrCreateTokenBalanceSrc(event: TransferEvent): TokenBalance {
+    let tokenBalanceSrcId = event.params.src.toHex() + event.address.toHex()
+    let tokenBalanceSrc = TokenBalance.load(tokenBalanceSrcId)
+    if (tokenBalanceSrc == null) {
+        tokenBalanceSrc = createTokenBalance(tokenBalanceSrcId, event, event.params.src.toHex())
+    }
+    tokenBalanceSrc.balance = tokenBalanceSrc.balance.minus(event.params.wad)
+    tokenBalanceSrc.save()
+    return <TokenBalance>tokenBalanceSrc
+}
+
+export function updateAccounts(event: TransferEvent): void {
+    // increase accountTo balance
+    let accountTo = Account.load(event.params.dst.toHex())
+    if (accountTo == null) {
+        accountTo = createAccount(event.params.dst.toHex())
+    }
+    accountTo.currentActiveInvestmentAmount = accountTo.currentActiveInvestmentAmount.plus(event.params.wad)
+    accountTo.save()    
+
+    // decrease accountFrom balance
+    let accountFrom = Account.load(event.params.src.toHex())
+    if (accountFrom == null) {
+        accountFrom = createAccount(event.params.src.toHex())
+    }
+    accountFrom.currentActiveInvestmentAmount = accountFrom.currentActiveInvestmentAmount.minus(event.params.wad)
+    accountFrom.save()
+} 

--- a/subgraph-mainnet-production.yaml
+++ b/subgraph-mainnet-production.yaml
@@ -27,6 +27,8 @@ dataSources:
           file: ./abis/v3/Assessor.json
         - name: SeniorTranche
           file: ./abis/SeniorTranche.json
+        - name: ERC20
+          file: ./abis/ERC20.json
       blockHandlers:
         - handler: handleBlock
       file: ./src/mapping.ts
@@ -702,4 +704,46 @@ dataSources:
           handler: handleNftFeedUpdate
         - function: update(bytes32,uint256)
           handler: handleNftFeedUpdate
+      file: ./src/mapping.ts
+  # senior token
+  - kind: ethereum/contract
+    name: CF4DROP
+    network: mainnet
+    source:
+      address: "0x5b2F0521875B188C0afc925B1598e1FF246F9306"
+      abi: ERC20
+      startBlock: 11063000
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      entities:
+        - Transfer
+      abis:
+        - name: ERC20
+          file: ./abis/ERC20.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleERC20Transfer
+      file: ./src/mapping.ts
+  # junior token
+  - kind: ethereum/contract
+    name: CF4TIN
+    network: mainnet
+    source:
+      address: "0x05DD145AA26dBDcc7774E4118E34Bb67C64661c6"
+      abi: ERC20
+      startBlock: 11063000
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      entities:
+        - Transfer
+      abis:
+        - name: ERC20
+          file: ./abis/ERC20.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleERC20Transfer
       file: ./src/mapping.ts

--- a/subgraph-mainnet-production.yaml
+++ b/subgraph-mainnet-production.yaml
@@ -56,7 +56,7 @@ dataSources:
           handler: handleCreateProxy
       file: ./src/mapping.ts
 
-  # CF1
+  # # CF1
   - kind: ethereum/contract
     name: Shelf
     network: mainnet

--- a/subgraph-mainnet-production.yaml
+++ b/subgraph-mainnet-production.yaml
@@ -56,7 +56,7 @@ dataSources:
           handler: handleCreateProxy
       file: ./src/mapping.ts
 
-  # # CF1
+  # CF1
   - kind: ethereum/contract
     name: Shelf
     network: mainnet


### PR DESCRIPTION
adds balance tracking across ERC20 transfer events for tinlakeV3 pools

see [here]( https://thegraph.com/explorer/subgraph/jennypollack/tinlake-rewards?query=tokens) for working example 

note that event id has been changed from `srcAddress + dstAddress + event.address.toHex() + event.params.wad.toHex()`
to `event.block.number.toString().concat('-').concat(event.logIndex.toString())`

which is what [ens](https://github.com/ensdomains/ens-subgraph) uses
