### PR TITLE
Fix bug that did not allow claiming/linking same Centrifuge Chain acc…

### DIFF
--- a/src/mappings/TinlakeClaimRAD.ts
+++ b/src/mappings/TinlakeClaimRAD.ts
@@ -2,7 +2,7 @@ import { log, BigDecimal } from '@graphprotocol/graph-ts'
 import { Claimed } from '../../generated/Claim/TinlakeClaimRAD'
 import { loadOrCreateRewardLink } from '../domain/RewardLink'
 import { loadOrCreateRewardBalance } from '../domain/Reward'
-import { pushUnique } from '../util/array'
+import { pushOrMoveLast, pushUnique } from '../util/array'
 
 export function handleClaimed(claimed: Claimed): void {
   let sender = claimed.params.claimer.toHex()
@@ -12,7 +12,7 @@ export function handleClaimed(claimed: Claimed): void {
 
   let balance = loadOrCreateRewardBalance(sender)
   let link = loadOrCreateRewardLink(sender, centAddress)
-  balance.links = pushUnique(balance.links, link.id)
+  balance.links = pushOrMoveLast(balance.links, link.id)
 
   // add this link to their reward balance and put any
   // claimable rewards into this link, reset linkableRewards to 0

--- a/src/util/array.ts
+++ b/src/util/array.ts
@@ -6,3 +6,9 @@ export function pushUnique(arr: string[], item: string): string[] {
   }
   return arr
 }
+
+export function pushOrMoveLast(arr: string[], item: string): string[] {
+  let temp = arr.filter((a) => a !== item)
+  temp.push(item)
+  return temp
+}


### PR DESCRIPTION
…ount twice

Context: 

When a user links `centAccA`, then `centAccB` and then `centAccA` again, the rewards will continue to go to `centAccB`. 

The reason for that is that when updating a Centrifuge Chain account link, we only check for existence to remove duplicates, but we don't move an existing link to the end of the links array. Rewards are always assigned to the last link, which means that an update to a previously existing account would be ineffective.

This is not a security concern, but it is unexpected behaviour in my view. 

This PR should fix the issue.