### PR TITLE
Fix build errors

### DIFF
--- a/src/domain/PoolRegistry.ts
+++ b/src/domain/PoolRegistry.ts
@@ -27,7 +27,8 @@ export function getAllPools(): string[] {
     return []
   }
 
-  log.debug('getAllPools: returning {} pools', [registry.pools.length.toString()])
+  let l = registry.pools.length;
+  log.debug('getAllPools: returning {} pools', [l.toString()])
 
   return registry.pools
 }

--- a/src/mappings/TinlakeClaimRAD.ts
+++ b/src/mappings/TinlakeClaimRAD.ts
@@ -1,5 +1,5 @@
 import { log, BigDecimal } from '@graphprotocol/graph-ts'
-import { Claimed } from '../../generated/Claim/TinlakeClaimRAD'
+import { Claimed } from '../../generated/Claim/TinlakeClaimRad'
 import { loadOrCreateRewardLink } from '../domain/RewardLink'
 import { loadOrCreateRewardBalance } from '../domain/Reward'
 import { pushOrMoveLast } from '../util/array'

--- a/subgraph-kovan-staging.yaml
+++ b/subgraph-kovan-staging.yaml
@@ -97,7 +97,7 @@ dataSources:
     network: kovan
     source: 
       address: "0x297237e17F327f8e5C8dEd78b15761A7D513353b"
-      abi: TinlakeClaimRAD
+      abi: TinlakeClaimRad
       startBlock: 22686539
     mapping:
       kind: ethereum/events
@@ -106,8 +106,8 @@ dataSources:
       entities:
         - RewardLink
       abis:
-        - name: TinlakeClaimRAD
-          file: ./abis/TinlakeClaimRAD.json
+        - name: TinlakeClaimRad
+          file: ./abis/TinlakeClaimRad.json
       eventHandlers:
         - event: Claimed(address,bytes32)
           handler: handleClaimed

--- a/subgraph-mainnet-production.yaml
+++ b/subgraph-mainnet-production.yaml
@@ -96,7 +96,7 @@ dataSources:
     network: mainnet
     source: 
       address: "0x1cA3B2E7FfCAF83d9228a64e4726402B1d5CC054"
-      abi: TinlakeClaimRAD
+      abi: TinlakeClaimRad
       startBlock: 11686325
     mapping:
       kind: ethereum/events
@@ -105,8 +105,8 @@ dataSources:
       entities:
         - RewardLink
       abis:
-        - name: TinlakeClaimRAD
-          file: ./abis/TinlakeClaimRAD.json
+        - name: TinlakeClaimRad
+          file: ./abis/TinlakeClaimRad.json
       eventHandlers:
         - event: Claimed(address,bytes32)
           handler: handleClaimed


### PR DESCRIPTION
This addresses two small build errors, one looks the result of some renaming, the other is related to assemblyscript versions. It appears as described [here](https://stackoverflow.com/questions/57897731/how-to-print-the-length-of-an-array-in-assemblyscript-near) for me with node versions 12, 14, and 15 and graph-ts 0.19