### PR TITLE
fix: bug that users who are no longer invested could not claim their …

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -86,8 +86,8 @@ type Proxy @entity {
 
 type Account @entity {
   id: ID! # account address
-  dailyTokenBalances: [DailyInvestorTokenBalance!] @derivedFrom (field: "account")
-  # used for reward calculations to determine if an investor has an active investment 
+  dailyTokenBalances: [DailyInvestorTokenBalance!] @derivedFrom(field: "account")
+  # used for reward calculations to determine if an investor has an active investment
   rewardCalcBitFlip: Boolean!
 }
 
@@ -121,7 +121,7 @@ type TokenBalance @entity {
   # Users can submit supplyOrder or redeemOrder to change their investment in the pool:
   # 1) A user can supply DAI which goes into the `pendingSupplyCurrency`
   # 2) After each epoch some or all of the pendingSupplyCurrency can be converted to pool shares (DROP/TIN) or some or all of the pendingRedeemToken can be converted to DAI. After each epoch the fulfillment percentage can increase.
-  # 3) Calling calcDisburse() gives you 4 values: 
+  # 3) Calling calcDisburse() gives you 4 values:
   #    - pendingSupplyCurrency: the amount of DAI not converted to tokens yet
   #    - supplyAmount: the amount of DROP/TIN you will get the next time you call `disburse`
   #    - pendingRedeemToken: the amount of tokens not redeemed to DAI yet
@@ -179,15 +179,35 @@ type RewardDayTotal @entity {
   toDateRewardAggregateValue: BigDecimal!
 }
 
-# on claim changed event from contract
-# create new reward link for the eth address
+"""
+Rewards accumulated by an account on Ethereum and links Centrifuge Chain accounts that can claim those rewards
+"""
 type RewardBalance @entity {
-  id: ID! # account address
+  """
+  Etherum account that earned rewards
+  """
+  id: ID!
+  """
+  Links to Centrifuge Chain accounts with rewards that are currently claimable
+  """
   links: [RewardLink!]!
-  claimable: Boolean! # rewards become claimable to cent chain after investment length is greater than 60 consecutive days
-  linkableRewards: BigDecimal! 
-  totalRewards: BigDecimal! # cumulative across links
-  nonZeroBalanceSince: BigInt # system wide, has to have a non zero balance for at least the past 60 consecutive days
+  """
+  Rewards that can be linked or claimed in the future. Rewards only become claimable after an Ethereum account has any
+  investment for at least 60 consecutive days. Until that is the case, rewards will accumulate in linkableRewards. After
+  the 60 days are over, rewards will automatically go to the last RewardLink in links. If there is no RewardLink in
+  links, rewards will stay in linkableRewards until a RewardLink is created.
+  """
+  linkableRewards: BigDecimal!
+  """
+  Sum of all rewards across links and linkableRewards
+  """
+  totalRewards: BigDecimal!
+  """
+  Timestamp (in seconds) since which the Ethereum account had a non-zero investment. Will be set to null when the
+  investment balance becomes zero on a day. If null and an investment is in the system, will be set to the timestamp of
+  that day.
+  """
+  nonZeroBalanceSince: BigInt
 }
 
 # this is a historical value and will not be responsible
@@ -200,9 +220,22 @@ type RewardByToken @entity {
   rewards: BigDecimal!
 }
 
+"""
+A link between an Ethereum account and an account on Centrifuge Chain. Any balance that are accumulated on that account
+are claimable on Centrifuge Chain
+"""
 type RewardLink @entity {
   id: ID! #eth address + cent address
+  """
+  Ethereum address that has earned the rewards
+  """
   ethAddress: String!
+  """
+  Hex encoded public key of an account on Centrifuge Chain that will receive rewards
+  """
   centAddress: String!
+  """
+  Rewards that are claimable by the Centrifuge Chain account
+  """
   rewardsAccumulated: BigDecimal!
 }

--- a/src/domain/DailyPoolData.ts
+++ b/src/domain/DailyPoolData.ts
@@ -97,7 +97,6 @@ function updateSystemWideNonZeroBalances(date: BigInt): void {
     // then reset their nzbs.
     if (!account.rewardCalcBitFlip) {
       accountRewardBalance.nonZeroBalanceSince = null
-      accountRewardBalance.claimable = false
     }
 
     // if they an active investment and the nzbs exists, keep it as it is

--- a/src/domain/PoolRegistry.ts
+++ b/src/domain/PoolRegistry.ts
@@ -27,7 +27,7 @@ export function getAllPools(): string[] {
     return []
   }
 
-  let l = registry.pools.length;
+  let l = registry.pools.length
   log.debug('getAllPools: returning {} pools', [l.toString()])
 
   return registry.pools

--- a/src/domain/Reward.ts
+++ b/src/domain/Reward.ts
@@ -121,10 +121,6 @@ export function calculateRewards(date: BigInt, pool: Pool): void {
       reward.linkableRewards = BigDecimal.fromString('0')
     }
     // if no linked address is found, we track reward in linkableRewards
-    else if (rewardsAreClaimable(date, reward.nonZeroBalanceSince)) {
-      reward.linkableRewards = reward.linkableRewards.plus(r)
-    }
-    // rewards not claimable
     else {
       reward.linkableRewards = reward.linkableRewards.plus(r)
     }

--- a/src/domain/Reward.ts
+++ b/src/domain/Reward.ts
@@ -42,7 +42,6 @@ export function loadOrCreateRewardBalance(address: string): RewardBalance {
   if (rb == null) {
     rb = new RewardBalance(address)
     rb.links = []
-    rb.claimable = false
     rb.linkableRewards = BigDecimal.fromString('0')
     rb.totalRewards = BigDecimal.fromString('0')
     rb.nonZeroBalanceSince = null
@@ -111,8 +110,6 @@ export function calculateRewards(date: BigInt, pool: Pool): void {
     // if rewards are claimable, and an address is linked
     // add them to the most recently linked address
     if (rewardsAreClaimable(date, reward.nonZeroBalanceSince) && reward.links.length > 0) {
-      reward.claimable = true
-
       let arr = reward.links
       let lastLinked = RewardLink.load(arr[arr.length - 1])
       lastLinked.rewardsAccumulated = lastLinked.rewardsAccumulated.plus(r)
@@ -125,7 +122,6 @@ export function calculateRewards(date: BigInt, pool: Pool): void {
     }
     // if no linked address is found, we track reward in linkableRewards
     else if (rewardsAreClaimable(date, reward.nonZeroBalanceSince)) {
-      reward.claimable = true
       reward.linkableRewards = reward.linkableRewards.plus(r)
     }
     // rewards not claimable

--- a/src/mappings/TinlakeClaimRAD.ts
+++ b/src/mappings/TinlakeClaimRAD.ts
@@ -1,10 +1,16 @@
-import { log, BigDecimal } from '@graphprotocol/graph-ts'
+import { log, BigDecimal, BigInt } from '@graphprotocol/graph-ts'
 import { Claimed } from '../../generated/Claim/TinlakeClaimRad'
 import { loadOrCreateRewardLink } from '../domain/RewardLink'
 import { loadOrCreateRewardBalance } from '../domain/Reward'
 import { pushOrMoveLast } from '../util/array'
+import { timestampToDate } from '../util/date'
+import { secondsInDay } from '../config'
+import { rewardsAreClaimable } from '../domain/Day'
 
 export function handleClaimed(claimed: Claimed): void {
+  let date = timestampToDate(claimed.block.timestamp)
+  let yesterday = date.minus(BigInt.fromI32(secondsInDay))
+
   let sender = claimed.params.claimer.toHex()
   let centAddress = claimed.params.account.toHex()
 
@@ -14,9 +20,9 @@ export function handleClaimed(claimed: Claimed): void {
   let link = loadOrCreateRewardLink(sender, centAddress)
   reward.links = pushOrMoveLast(reward.links, link.id)
 
-  // add this link to their reward balance and put any
+  // if rewards are claimable, add this link to their reward balance and put any
   // claimable rewards into this link, reset linkableRewards to 0
-  if (reward.claimable) {
+  if (rewardsAreClaimable(yesterday, reward.nonZeroBalanceSince)) {
     link.rewardsAccumulated = link.rewardsAccumulated.plus(reward.linkableRewards)
     reward.linkableRewards = BigDecimal.fromString('0')
   }


### PR DESCRIPTION
…RAD rewards anymore

This change implies that claimable will no longer be reset, i. e. any investor that has ever invested for 60 consecutive days will be able to claim any future rewards, even if they were not invested for another 60 days.