### PR TITLE
bump to 5.6 million

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@ export const blockTimeSeconds = 15
 
 export let fixed27 = BigInt.fromI32(10).pow(27)
 
-export const rewardsCeiling = '2000000000000000000000000000000000'
+export const rewardsCeiling = '5600000000000000000000000000000000'
 
 export const zeroAddress = '0x0000000000000000000000000000000000000000'
 


### PR DESCRIPTION
per conversation on the forum: https://gov.centrifuge.io/t/request-for-comments-cfg-liquidity-rewards-parameter-update/1931
the reward threshold is being upped to 5.6 million CFG