### PR TITLE
Feat: Only accrue rewards for linked accounts

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -96,6 +96,7 @@ type Account @entity {
   dailyTokenBalances: [DailyInvestorTokenBalance!] @derivedFrom(field: "account")
   # used for reward calculations to determine if an investor has an active investment
   rewardCalcBitFlip: Boolean!
+  hasLinkedCfgAccount: Boolean!
 }
 
 type ERC20Transfer @entity {

--- a/src/domain/Account.ts
+++ b/src/domain/Account.ts
@@ -6,6 +6,7 @@ import { pushUnique } from '../util/array'
 export function createAccount(address: string): Account {
   let account = new Account(address)
   account.rewardCalcBitFlip = false
+  account.hasLinkedCfgAccount = false
   account.save()
   return account
 }

--- a/src/domain/Account.ts
+++ b/src/domain/Account.ts
@@ -11,6 +11,17 @@ export function createAccount(address: string): Account {
   return account
 }
 
+export function loadOrCreateAccount(address: string): Account {
+  let account = Account.load(address);
+  if (account == null) {
+    account = new Account(address)
+    account.rewardCalcBitFlip = false
+    account.hasLinkedCfgAccount = false
+    account.save()
+  }
+  return <Account>account
+}
+
 export function loadOrCreateGlobalAccounts(id: string): GlobalAccountId {
   let ids = GlobalAccountId.load(id)
   if (!ids) {

--- a/src/domain/Reward.ts
+++ b/src/domain/Reward.ts
@@ -3,6 +3,7 @@ import { Address, BigInt, BigDecimal, log, ethereum } from '@graphprotocol/graph
 import { CfgRewardRate } from '../../generated/Block/CfgRewardRate'
 import { CfgSplitRewardRate } from '../../generated/Block/CfgSplitRewardRate'
 import {
+  Account,
   DailyInvestorTokenBalance,
   Pool,
   PoolAddresses,
@@ -106,6 +107,11 @@ export function calculateRewards(date: BigInt, pool: Pool): void {
     let ditb = DailyInvestorTokenBalance.load(account.concat(pool.id).concat(date.toString()))
     if (!!ditb) {
       let reward = loadOrCreateRewardBalance(ditb.account)
+
+      let accountEntity = Account.load(account)
+      if (accountEntity != null && accountEntity.hasLinkedCfgAccount == false) {
+        continue
+      }
 
       updateInvestorRewardsByToken(
         <PoolAddresses>tokenAddresses,

--- a/src/mappings/TinlakeClaimRad.ts
+++ b/src/mappings/TinlakeClaimRad.ts
@@ -8,6 +8,7 @@ import { timestampToDate } from '../util/date'
 import { secondsInDay } from '../config'
 import { rewardsAreClaimable } from '../domain/Day'
 import { Account, PoolsByAORewardRecipient } from '../../generated/schema'
+import { loadOrCreateAccount } from '../domain/Account'
 
 export function handleClaimed(claimed: Claimed): void {
   let date = timestampToDate(claimed.block.timestamp)
@@ -20,11 +21,9 @@ export function handleClaimed(claimed: Claimed): void {
 
   let link = loadOrCreateRewardLink(sender, centAddress)
 
-  let account = Account.load(sender);
-  if (account != null) {
-    account.hasLinkedCfgAccount = true;
-    account.save();
-  }
+  let account = loadOrCreateAccount(sender)
+  account.hasLinkedCfgAccount = true;
+  account.save();
   // update both investor and AO reward balances. An eth address could be used for both, so update both.
 
   // update investor reward balance

--- a/src/mappings/TinlakeClaimRad.ts
+++ b/src/mappings/TinlakeClaimRad.ts
@@ -7,7 +7,7 @@ import { pushOrMoveLast } from '../util/array'
 import { timestampToDate } from '../util/date'
 import { secondsInDay } from '../config'
 import { rewardsAreClaimable } from '../domain/Day'
-import { PoolsByAORewardRecipient } from '../../generated/schema'
+import { Account, PoolsByAORewardRecipient } from '../../generated/schema'
 
 export function handleClaimed(claimed: Claimed): void {
   let date = timestampToDate(claimed.block.timestamp)
@@ -20,6 +20,10 @@ export function handleClaimed(claimed: Claimed): void {
 
   let link = loadOrCreateRewardLink(sender, centAddress)
 
+  let account = Account.load(sender);
+  if (account != null) {
+    account.hasLinkedCfgAccount = true;
+  }
   // update both investor and AO reward balances. An eth address could be used for both, so update both.
 
   // update investor reward balance

--- a/src/mappings/TinlakeClaimRad.ts
+++ b/src/mappings/TinlakeClaimRad.ts
@@ -23,6 +23,7 @@ export function handleClaimed(claimed: Claimed): void {
   let account = Account.load(sender);
   if (account != null) {
     account.hasLinkedCfgAccount = true;
+    account.save();
   }
   // update both investor and AO reward balances. An eth address could be used for both, so update both.
 


### PR DESCRIPTION
This PR adds a `hasLinkedCfgAccount` attribute to the `account` entity. This is set to `true` in the handleClaim handler, and then we check for this in the `CalculateRewards()` function and leave early if the boolean is `false`.