### PR TITLE
chore: update fastForward mainnet value

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,7 @@ export const zeroAddress = '0x0000000000000000000000000000000000000000'
  *
  * Therefore, this value should be set to the latest block before every new deployment.
  */
-const fastForwardUntilBlockMainnet = 12909095
+const fastForwardUntilBlockMainnet = 13817906
 const fastForwardUntilBlockKovan = 26403984
 export let fastForwardUntilBlock =
   dataSource.network() == 'mainnet' ? fastForwardUntilBlockMainnet : fastForwardUntilBlockKovan


### PR DESCRIPTION
### Description

This pull request updates the value for `fastForwardUntilBlockMainnet` to a recent block so that future syncing is faster.