### PR TITLE
Allow null maturity date

### DIFF
--- a/src/mappings/Block.ts
+++ b/src/mappings/Block.ts
@@ -21,7 +21,6 @@ export function handleBlock(block: ethereum.Block): void {
   if (
     block.number.mod(BigInt.fromI32((handleBlockFrequencyMinutes * 60) / blockTimeSeconds)).notEqual(BigInt.fromI32(0))
   ) {
-    log.info('handleBlock: skip block {}', [block.number.toString()])
     return
   }
 

--- a/src/mappings/Shelf.ts
+++ b/src/mappings/Shelf.ts
@@ -80,7 +80,7 @@ export function handleShelfIssue(call: IssueCall): void {
   let maturityDate = navFeed.try_maturityDate(nftHash.value)
   if (maturityDate.reverted) {
     log.error('handleShelfIssue: failed to find maturity date for nft hash {}', [nftHash.value.toString()])
-    return
+    // return
   }
 
   // get ratePerSecond for riskgroup
@@ -93,7 +93,7 @@ export function handleShelfIssue(call: IssueCall): void {
   // set ceiling & threshold based on collateral value
   loan.ceiling = navFeed.ceiling(loanIndex)
   loan.threshold = navFeed.threshold(loanIndex)
-  loan.maturityDate = maturityDate.value
+  loan.maturityDate = maturityDate.reverted ? null : maturityDate.value
 
   log.info('handleShelfIssue: will save loan {} (pool: {}, index: {}, owner: {}, opened {})', [
     loan.id,

--- a/src/mappings/Shelf.ts
+++ b/src/mappings/Shelf.ts
@@ -80,7 +80,6 @@ export function handleShelfIssue(call: IssueCall): void {
   let maturityDate = navFeed.try_maturityDate(nftHash.value)
   if (maturityDate.reverted) {
     log.error('handleShelfIssue: failed to find maturity date for nft hash {}', [nftHash.value.toString()])
-    // return
   }
 
   // get ratePerSecond for riskgroup
@@ -169,7 +168,8 @@ export function handleShelfBorrow(call: BorrowCall): void {
   let navFeed = NavFeed.bind(Address.fromString(addresses.feed))
   loan.ceiling = navFeed.ceiling(loanIndex)
   let nftID = navFeed.nftID(loanIndex)
-  loan.maturityDate = navFeed.maturityDate(nftID)
+  let maturityDate = navFeed.try_maturityDate(nftID)
+  loan.maturityDate = maturityDate.reverted ? null : maturityDate.value
   loan.financingDate = call.block.timestamp
   loan.save()
 

--- a/subgraph-mainnet-production.yaml
+++ b/subgraph-mainnet-production.yaml
@@ -2,7 +2,7 @@ specVersion: 0.0.2
 description: Tinlake Mainnet Production
 graft:
   base: QmWGSpvcQrhqXkamHMqVG4rjuEXZ3TXNPAJpr4J1oaTqe4
-  block: 16229770
+  block: 16235450
 schema:
   file: ./schema.graphql
 dataSources:

--- a/subgraph-mainnet-production.yaml
+++ b/subgraph-mainnet-production.yaml
@@ -1,7 +1,7 @@
 specVersion: 0.0.2
 description: Tinlake Mainnet Production
 graft:
-  base: QmWGSpvcQrhqXkamHMqVG4rjuEXZ3TXNPAJpr4J1oaTqe4
+  base: QmSHHZnxttkoPxfsXnFfAcCmsXdFGkpH5X6ZmnWK8yYC1d
   block: 16235450
 schema:
   file: ./schema.graphql


### PR DESCRIPTION
Allows the maturity date eth calls to gracefully revert and use null in such cases, instead of causing an indexing error. Also removes the "skip block" log, as it's not necessary and bloats the log files