### PR TITLE
Filter closed loans

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -72,7 +72,7 @@ type Loan @entity {
   nftRegistry: Bytes!
   owner: Bytes!
   opened: Int!
-  closed: Int
+  closed: Int! # type Int is non-nullable, so a value of 0 indicates that the loan is still open
   debt: BigInt!
   interestRatePerSecond: BigInt
   ceiling: BigInt

--- a/src/domain/Loan.ts
+++ b/src/domain/Loan.ts
@@ -23,7 +23,7 @@ export function updateLoans(pool: Pool, pileAddress: string): BigInt[] {
     }
 
     // Ignore closed loans
-    if (loan.closed != null) {
+    if (loan.closed === 0) {
       log.info('updateLoans: loan {} is closed. Will not proceed with update', [loanId])
       return [new BigInt(0), new BigInt(0)]
     }

--- a/src/mappings/Shelf.ts
+++ b/src/mappings/Shelf.ts
@@ -44,6 +44,7 @@ export function handleShelfIssue(call: IssueCall): void {
   loan.index = loanIndex.toI32()
   loan.owner = loanOwner
   loan.opened = call.block.timestamp.toI32()
+  loan.closed = 0
   loan.debt = BigInt.fromI32(0)
   loan.borrowsCount = 0
   loan.borrowsAggregatedAmount = BigInt.fromI32(0)

--- a/subgraph-mainnet-production.yaml
+++ b/subgraph-mainnet-production.yaml
@@ -1,8 +1,5 @@
 specVersion: 0.0.2
 description: Tinlake Mainnet Production
-graft:
-  base: QmSHHZnxttkoPxfsXnFfAcCmsXdFGkpH5X6ZmnWK8yYC1d
-  block: 16235450
 schema:
   file: ./schema.graphql
 dataSources:


### PR DESCRIPTION
The Tinlake subgraph makes an a LOT of eth_calls updating closed loans `debt` values, which currently is slowing down the subgraph to the point where it can't always stay in sync with the latest block on eth mainnet. This PR filters out closed loans when updating loans.

In order to do this, I had to set the default value for the `closed` attribute on the `Loan` schema object to `0` instead of `null`, as the Int type in assembly script is non-nullable, checking its value throws an error if it hasn't been set yet.

This subgraph is currently deployed at http://graph.cntrfg.com/subgraphs/name/filter-loans and is able to remain fully synced, while our current prod subgraph struggles to keep up (https://graph.centrifuge.io/subgraphs/name/allow-null-maturity-date)